### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/shinu61/6664a141-e593-43d5-ae62-da2c0d000bab/47f09968-e7ee-43a6-9d99-494c7c593b5a/_apis/work/boardbadge/681ae72f-c07e-4ea9-9185-ed909cf11404)](https://dev.azure.com/shinu61/6664a141-e593-43d5-ae62-da2c0d000bab/_boards/board/t/47f09968-e7ee-43a6-9d99-494c7c593b5a/Microsoft.RequirementCategory)
 # Daily
 Daily work


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shinu61/6664a141-e593-43d5-ae62-da2c0d000bab/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.